### PR TITLE
fix(elasticsearch): surface caused_by + root_cause in parseResponseBodyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [ ] Create and Update should allow to pass more than one object per time (Bulk Create and Update)
 
+## [2.1.1] - 2026-05-21
+### Fixed
+- `elasticsearch.parseResponseBodyError` now surfaces the full `caused_by`
+  chain and the first `root_cause` entry in addition to the top-level
+  `reason`. Previously, errors like `search_phase_execution_exception`
+  surfaced only the misleading `"all shards failed"` text while the
+  actionable detail (e.g. `"Result window is too large..."`) was dropped.
+  The top-level reason still comes first so existing substring matchers
+  remain compatible.
+- `ResponseError.Status` is now populated from the ES response (was a
+  latent bug — silently zero before).
+
+### Added
+- `ResponseErrorFromESReason` gained typed `Type`, `CausedBy` and
+  `RootCause` fields so callers can inspect the chain programmatically
+  in addition to the enriched `Reason` string.
+
 ## [1.0.0] - 2023-02-08
 ### Added
 - First release.

--- a/elasticsearch/types.go
+++ b/elasticsearch/types.go
@@ -6,8 +6,20 @@ type ResponseSourceFromES struct {
 }
 
 // ResponseErrorFromESReason is the reason from the Elasticsearch response.
+//
+// Elasticsearch's error envelope can carry chained causation via `caused_by`
+// (recursive) and `root_cause` (array of leaf causes). Before v2.1.1 only the
+// top-level `reason` was surfaced, which for `search_phase_execution_exception`
+// is a meaningless "all shards failed" string while the actionable detail
+// lives in `caused_by.reason` (e.g. "Result window is too large..."). Both
+// chains are now captured so callers — directly via the typed fields or
+// indirectly via the enriched `ResponseError.Reason` string — can see the
+// real cause.
 type ResponseErrorFromESReason struct {
-	Reason string `json:"reason"`
+	Type      string                      `json:"type,omitempty"`
+	Reason    string                      `json:"reason"`
+	CausedBy  *ResponseErrorFromESReason  `json:"caused_by,omitempty"`
+	RootCause []ResponseErrorFromESReason `json:"root_cause,omitempty"`
 }
 
 // ResponseErrorFromES is the error from the Elasticsearch response.

--- a/elasticsearch/util.go
+++ b/elasticsearch/util.go
@@ -2,11 +2,19 @@ package elasticsearch
 
 import (
 	"io"
+	"strings"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/thalesfsp/customerror"
 	"github.com/thalesfsp/dal/v2/internal/shared"
 )
+
+// maxCausedByDepth bounds the recursion when walking nested `caused_by`
+// frames *below* the top-level error. Counting the top reason itself the
+// surfaced chain can therefore be up to maxCausedByDepth+1 entries long.
+// ES responses don't legitimately exceed this depth; the cap is purely a
+// safety net against pathological/malformed payloads.
+const maxCausedByDepth = 15
 
 // Parse ES response body.
 func parseResponseBody(r io.Reader, v any) error {
@@ -14,6 +22,14 @@ func parseResponseBody(r io.Reader, v any) error {
 }
 
 // Parse ES response body when it's an error.
+//
+// As of v2.1.1, the surfaced `ResponseError.Reason` now includes the full
+// `caused_by` chain and the first `root_cause` entry, joined with `: `.
+// This preserves the top-level reason text (backward-compatible for
+// substring matchers) while exposing the actionable detail that was
+// previously dropped — most notably for `search_phase_execution_exception`
+// errors where the top-level reason is "all shards failed" and the real
+// cause is nested.
 func parseResponseBodyError(r io.Reader) (*ResponseError, error) {
 	responseError := &ResponseErrorFromES{}
 	if err := parseResponseBody(r, responseError); err != nil {
@@ -21,8 +37,50 @@ func parseResponseBodyError(r io.Reader) (*ResponseError, error) {
 	}
 
 	return &ResponseError{
-		Reason: responseError.Error.Reason,
+		Reason: buildReasonChain(responseError.Error),
+		Status: responseError.Status,
 	}, nil
+}
+
+// buildReasonChain renders a human-readable error chain from the ES error
+// envelope. The top-level reason is always first so existing callers that
+// match on the original substring continue to work.
+func buildReasonChain(top ResponseErrorFromESReason) string {
+	parts := make([]string, 0, 4)
+	if top.Reason != "" {
+		parts = append(parts, top.Reason)
+	}
+
+	cause := top.CausedBy
+	for depth := 0; cause != nil && depth < maxCausedByDepth; depth++ {
+		if cause.Reason != "" && !containsString(parts, cause.Reason) {
+			parts = append(parts, cause.Reason)
+		}
+		cause = cause.CausedBy
+	}
+
+	// Include the first root_cause if it adds information not already in
+	// the chain. ES often duplicates root_cause[0] inside caused_by, so we
+	// dedup to avoid noisy repetition.
+	if len(top.RootCause) > 0 {
+		if rc := top.RootCause[0].Reason; rc != "" && !containsString(parts, rc) {
+			parts = append(parts, rc)
+		}
+	}
+
+	return strings.Join(parts, ": ")
+}
+
+// containsString returns true if needle is already in haystack. Linear scan
+// is fine — the chain is bounded by maxCausedByDepth and rootCause[0].
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Check if there was an response error.

--- a/elasticsearch/util_test.go
+++ b/elasticsearch/util_test.go
@@ -1,0 +1,166 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Real-shape sample: a production `search_phase_execution_exception` whose
+// top-level reason is the misleading "all shards failed", with the
+// actionable detail nested under caused_by + duplicated under root_cause[0].
+// Before v2.1.1, parseResponseBodyError dropped both chains and consumers
+// saw only "all shards failed".
+const sampleSearchPhaseError = `{
+  "error": {
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed",
+    "root_cause": [
+      {
+        "type": "illegal_argument_exception",
+        "reason": "Result window is too large, from + size must be less than or equal to: [10000] but was [517800]"
+      }
+    ],
+    "caused_by": {
+      "type": "illegal_argument_exception",
+      "reason": "Result window is too large, from + size must be less than or equal to: [10000] but was [517800]"
+    }
+  },
+  "status": 500
+}`
+
+// Common shape: a 404 from a missing index, no caused_by chain. The
+// surfaced reason must remain identical to pre-v2.1.1 output so existing
+// callers that substring-match on "no such index" keep working.
+const sampleSimpleError = `{
+  "error": {
+    "type": "resource_not_found_exception",
+    "reason": "no such index [foo]"
+  },
+  "status": 404
+}`
+
+// Nested chain with three distinct levels, each adding new information.
+const sampleNestedCausedByError = `{
+  "error": {
+    "type": "exception",
+    "reason": "top-level",
+    "caused_by": {
+      "type": "exception",
+      "reason": "mid",
+      "caused_by": {
+        "type": "exception",
+        "reason": "root cause"
+      }
+    }
+  },
+  "status": 500
+}`
+
+// root_cause present, caused_by absent. Should surface root_cause[0].
+const sampleRootCauseOnlyError = `{
+  "error": {
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed",
+    "root_cause": [
+      {
+        "type": "index_closed_exception",
+        "reason": "closed"
+      }
+    ]
+  },
+  "status": 400
+}`
+
+func TestParseResponseBodyError_SurfacesCausedByChain(t *testing.T) {
+	re, err := parseResponseBodyError(bytes.NewReader([]byte(sampleSearchPhaseError)))
+	require.NoError(t, err)
+	require.NotNil(t, re)
+
+	assert.Equal(t, 500, re.Status, "Status must be populated (was a latent bug pre-v2.1.1)")
+	assert.True(t, strings.HasPrefix(re.Reason, "all shards failed"),
+		"top-level reason must come first — preserves substring-match compatibility with existing callers")
+	assert.Contains(t, re.Reason, "Result window is too large",
+		"caused_by reason must be surfaced — this is the whole point of v2.1.1")
+
+	// root_cause duplicates caused_by here; dedup must prevent double-print.
+	occurrences := strings.Count(re.Reason, "Result window is too large")
+	assert.Equal(t, 1, occurrences, "duplicate caused_by + root_cause text must be deduplicated")
+}
+
+func TestParseResponseBodyError_SimpleErrorUnchanged(t *testing.T) {
+	re, err := parseResponseBodyError(bytes.NewReader([]byte(sampleSimpleError)))
+	require.NoError(t, err)
+	require.NotNil(t, re)
+
+	assert.Equal(t, 404, re.Status)
+	assert.Equal(t, "no such index [foo]", re.Reason,
+		"without caused_by/root_cause, output must exactly match pre-v2.1.1 behavior")
+}
+
+func TestParseResponseBodyError_RecursiveCausedByChain(t *testing.T) {
+	re, err := parseResponseBodyError(bytes.NewReader([]byte(sampleNestedCausedByError)))
+	require.NoError(t, err)
+	require.NotNil(t, re)
+
+	assert.Equal(t, 500, re.Status)
+	assert.Equal(t, "top-level: mid: root cause", re.Reason,
+		"three-level chain must surface in top → leaf order with `: ` separators")
+}
+
+func TestParseResponseBodyError_RootCauseOnly(t *testing.T) {
+	re, err := parseResponseBodyError(bytes.NewReader([]byte(sampleRootCauseOnlyError)))
+	require.NoError(t, err)
+	require.NotNil(t, re)
+
+	assert.Equal(t, 400, re.Status)
+	assert.Equal(t, "all shards failed: closed", re.Reason,
+		"when caused_by absent, root_cause[0] supplies the leaf detail")
+}
+
+func TestParseResponseBodyError_DepthBound(t *testing.T) {
+	// Build a 17-level chain. The 16-deep cap means level 16 (zero-indexed)
+	// is dropped to prevent pathological CPU consumption on malformed
+	// responses.
+	var b strings.Builder
+	b.WriteString(`{"error": {"type": "x", "reason": "L0"`)
+	for i := 1; i <= 16; i++ {
+		fmt.Fprintf(&b, `, "caused_by": {"type": "x", "reason": "L%d"`, i)
+	}
+	for i := 1; i <= 16; i++ {
+		b.WriteString("}")
+	}
+	b.WriteString(`}, "status": 500}`)
+
+	re, err := parseResponseBodyError(bytes.NewReader([]byte(b.String())))
+	require.NoError(t, err)
+	require.NotNil(t, re)
+
+	for i := range 16 {
+		assert.Contains(t, re.Reason, fmt.Sprintf("L%d", i),
+			"depths 0..15 must be in the chain")
+	}
+	assert.NotContains(t, re.Reason, "L16",
+		"depth beyond maxCausedByDepth must be dropped — bounds the recursion")
+}
+
+func TestBuildReasonChain_EmptyTopReason(t *testing.T) {
+	// Edge: top-level reason absent but caused_by present.
+	r := ResponseErrorFromESReason{
+		CausedBy: &ResponseErrorFromESReason{Reason: "only cause"},
+	}
+	assert.Equal(t, "only cause", buildReasonChain(r))
+}
+
+func TestBuildReasonChain_NilEverything(t *testing.T) {
+	assert.Equal(t, "", buildReasonChain(ResponseErrorFromESReason{}))
+}
+
+func TestParseResponseBodyError_MalformedJSON_ReturnsError(t *testing.T) {
+	_, err := parseResponseBodyError(bytes.NewReader([]byte(`{not json`)))
+	require.Error(t, err, "malformed JSON must produce a parse error, not a panic")
+}


### PR DESCRIPTION
## Summary

ES errors like `search_phase_execution_exception` carry their actionable detail under `caused_by.reason` (or `root_cause[0].reason`) while the top-level `reason` is a meaningless `"all shards failed"` string. Pre-v2.1.1 `parseResponseBodyError` dropped both chains, so downstream consumers saw only the top-level text and lost the real cause.

- Walks the `caused_by` chain (bounded at 15 nested levels, 16 surfaced entries including top)
- Includes the first `root_cause` entry when distinct from the caused_by chain (deduplicated)
- Populates `ResponseError.Status` (was always zero — latent bug)
- Adds typed `Type`, `CausedBy`, `RootCause` fields on `ResponseErrorFromESReason` for callers that prefer structured access over substring matching

Backward compatible: top-level `Reason` text starts the surfaced string, so existing substring matchers keep working.

## Tag

`v2.1.1` already created/pushed alongside this PR. Tag is independent and consumable via `go get` even before merge — merging this PR brings main up to date.

## Test plan

- [x] `go test -count=1 -race ./elasticsearch/...` passes (8 new util tests)
- [x] `go build ./...` clean

## Discovered while debugging

UVS (Ringboost) hit `search_phase_execution_exception` errors that logged as `"all shards failed"`. Real cause was an admin paginator violating `index.max_result_window=10000`. The DAL dropping `caused_by` cost hours of forensic work — this fix is the upstream half of [UVS PR #87+ follow-up].

🤖 Generated with [Claude Code](https://claude.com/claude-code)