### PR TITLE
chore(ci): bump Elasticsearch service image 8.4.3 → 8.15.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,13 @@ jobs:
       #   command: foo:pass:::upload
 
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.4.3
+        # Bumped from 8.4.3 because the JDK bundled with 8.4.3 crashes on
+        # ubuntu-latest GitHub runners (Ubuntu 24.04) with
+        # `CgroupV2Subsystem.getInstance` NPE — the cgroup v2 mount layout
+        # changed in newer kernels and the older JDK can't read it. 8.15.x
+        # ships a fixed JDK. Cluster-side compatibility is unaffected:
+        # go-elasticsearch v8 client works against any v8.x server.
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: -Xms512m -Xmx512m


### PR DESCRIPTION
## Summary

The CI's Elasticsearch 8.4.3 service container has been failing every run since GitHub Actions' `ubuntu-latest` rolled to Ubuntu 24.04. The bundled JDK in ES 8.4.3 hits `CgroupV2Subsystem.getInstance` NPE on the new cgroup-v2 mount layout and exits before the cluster ever starts up — meaning the Go test step never runs.

Bumping to 8.15.0 (newer JDK, cgroup-fix included) restores CI.

## Why now

PR #7 (and any future PR) is blocked by this. Tag `v2.1.1` is already live and consumable via Go proxy, but main can't catch up to it until CI passes again.

## Test plan

- [x] Diff: 1 line changed (image tag)
- [ ] CI: this PR's own Go workflow run — should reach the Go test step (currently never gets past container init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)