### PR TITLE
fix(sql): honor caller-provided List/Count Search instead of overwriting it

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,172 @@
+# DAL `List` / `Count` Search-Overwrite Bug — Analysis
+
+Repo: `github.com/thalesfsp/dal/v2` — analyzed at local `main` HEAD
+`cf34d8ac40259db8268a4a86e7b1a80148345aee` (module tag v2.1.1).
+
+## 1. Exact defect + root cause (file:line)
+
+The SQL storages resolve the query to run into `finalParam.Search`. The intent
+is: **if the caller supplies a `Search`, use it; otherwise default to
+`SELECT * FROM <target>`.** The implemented logic is inverted and overwrites the
+caller's `Search` with the default in exactly the case it should be honored.
+
+### mysql/mysql.go — `List` (pre-fix lines 545-557)
+
+```go
+defaultSearch := "SELECT * FROM " + trgt
+
+if finalParam.Search == "" {          // finalParam is fresh from list.New(); Search is ALWAYS ""
+    finalParam.Search = defaultSearch  //   -> so this always sets the default
+}
+
+if prm != nil {
+    if prm.Search != "" {              // BUG: when the caller DID provide a Search...
+        prm.Search = defaultSearch     //   ...OVERWRITE it with the default (SELECT * FROM target)
+    }
+    finalParam = prm
+}
+```
+
+Then (pre-fix line 569):
+
+```go
+m.Client.SelectContext(ctx, v, finalParam.Search)   // no bind args at all
+```
+
+**Root cause:** the `if prm.Search != ""` guard has inverted intent. It clobbers
+a non-empty caller `Search` with the default. The first `if finalParam.Search ==
+""` block operates on the fresh `list.New()` value (always empty) and is dead
+with respect to the caller. Net effect: **`List` can never filter** — every call
+returns `SELECT * FROM target` regardless of the caller's `Search`.
+
+Second, latent failure: when the caller passes a **non-nil** params struct with
+an **empty** `Search` (`&list.List{Search: ""}`), `finalParam = prm` leaves
+`Search == ""`, and `SelectContext(ctx, v, "")` is executed with an empty
+statement — which **hangs** the `mattn/go-sqlite3` driver (observed in tests).
+
+### Identical defect, all six sites
+
+The same inverted block exists in **`Count`** (with `SELECT COUNT(*) FROM ...`)
+and is duplicated verbatim across all three SQL storages:
+
+| Storage   | `List`        | `Count`       |
+|-----------|---------------|---------------|
+| mysql     | ~L545-557     | ~L186-198     |
+| postgres  | ~L536-548     | ~L177-189     |
+| sqlite    | ~L536-548     | ~L177-189     |
+
+## 2. Blast radius — which storages are affected
+
+**Affected: mysql, postgres, sqlite** (all three share the same copy-pasted
+block and the same `params/v2/list` + `params/v2/count` contract).
+
+**Not affected:** `elasticsearch`, `redis`, `mongodb`, `s3`, `file`, `sftp`,
+`memory`, `dynamodb` — they have their own `List`/`Count` implementations that do
+not contain this inverted `prm.Search` overwrite. (`elasticsearch` uses
+`finalParam.Search` as an ES query and honors a caller `Search`.)
+
+## 3. Impact
+
+- **Correctness (primary):** `List`/`Count` with a caller `Search`/filter is
+  silently ignored on SQL storages — you always get the full table (or full
+  count). Callers relying on `Search` to filter get wrong (unfiltered) results
+  with no error. `LIMIT`/`OFFSET`/`ORDER BY` expressed via `Search` are likewise
+  discarded.
+- **Availability:** a non-nil params struct with an empty `Search` produces an
+  empty SQL string, which hangs the SQLite driver (and is malformed for others).
+- **Injection angle:** the documented contract is that `List`/`Count` "uses
+  `param.List.Search` to query the data" — i.e. `Search` is a **caller-supplied,
+  trusted query template**, not untrusted end-user input. The storage layer does
+  **not** concatenate any untrusted value into the query; the only interpolation
+  is `target` in the default `SELECT ... FROM <target>` path. NOTE: `target`
+  resolves via `shared.TargetName` from the caller-supplied target argument (or
+  the storage's configured `m.Target`) — it is caller/operator-controlled, NOT
+  strictly server-only, and this is unchanged by the fix (pre-existing). It never
+  comes from `prm.Search`. The fix preserves this: the caller's `Search` is
+  passed **verbatim** to `SelectContext` (proved by a quote-in-value test
+  round-trip), and no new value concatenation is introduced. Callers remain
+  responsible for parameterizing untrusted values inside their own `Search` (the
+  public interface exposes no separate bind-args slot — a pre-existing API shape,
+  unchanged here).
+
+## 4. Consumers — proj-ringboost-vendor (UVS) backward-compatibility
+
+UVS (`github.com/WreckingBallStudioLabs/proj-ringboost-vendor`, on
+`dal/v2 v2.1.0`) uses these dal storages: **elasticsearch (60 imports), redis
+(40), postgres (5, wired in `cmd/storage.go`)**.
+
+- Every `List`/`Count` consumer that passes a non-empty `Search` reads
+  `storages[elasticsearch.Name]` (15 call sites — pricer, areacode, localizer,
+  phonenumber, etc.). The pricer (`internal/pricer/pricing.go:260`,
+  `util.go:670`) lists against **Elasticsearch** with an ES query-DSL `Search`
+  (`{"bool":{"must":[...]}}`). **Elasticsearch is not affected by this bug.**
+- The **postgres** storage is initialized and registered but **never has `.List`
+  or `.Count` invoked on it** anywhere in UVS (verified by grep across the repo).
+  It is used for other operations, not filtered listing.
+
+**Verdict — fully backward-compatible:**
+- UVS never exercised the buggy SQL `Search` path, so the current bug does **not**
+  mask anything in UVS, and the fix does **not** change any behavior UVS relies
+  on today.
+- For the only SQL-List shape UVS could hit (nil params / no custom `Search`),
+  the fix is behavior-preserving: it still defaults to `SELECT * FROM target`.
+- The fix is purely additive to correctness: previously-ignored caller `Search`
+  filters now work; the default (no-Search) path is byte-for-byte the same query.
+  No public interface signature changes.
+
+## 5. Fix
+
+Replace the inverted block at all six sites with straightforward precedence.
+`prm` is shallow-COPIED before defaulting so the caller-owned params struct is
+never mutated (previously, defaulting an empty `Search` would have written the
+default query back into the caller's struct):
+
+```go
+// Honor a caller-provided Search; only default when none was supplied.
+// Copy prm so defaulting never mutates the caller-owned params struct.
+if prm != nil {
+    prmCopy := *prm
+    finalParam = &prmCopy
+}
+
+if finalParam.Search == "" {
+    finalParam.Search = "SELECT * FROM " + trgt   // or "SELECT COUNT(*) FROM " for Count
+}
+```
+
+- Caller `Search` non-empty  -> used verbatim (filtering now works).
+- Caller `Search` empty / nil params -> defaults to `SELECT * FROM target`
+  (unchanged behavior; also fixes the empty-string hang).
+- No untrusted-value concatenation is introduced; the only interpolation remains
+  `target` (caller/operator-controlled via `shared.TargetName`, not `prm.Search`).
+- `prm` is shallow-COPIED before defaulting so the caller-owned params struct is
+  never mutated by DAL's defaulting (previously an empty `Search` would have had
+  the default query written back into it).
+
+## 6. Tests
+
+`sqlite/sqlite_list_test.go` (new) exercises the **real** `List`/`Count` code
+path fully offline against an isolated file-backed SQLite DB (no docker, no
+`ENVIRONMENT` gate), so it runs under `make test`:
+
+- **happy:** nil params -> all rows / full count; `Search` filter -> correct
+  subset / filtered count.
+- **edge:** `LIMIT`/`OFFSET` pagination honored; `ORDER BY` honored; empty
+  `Search` falls back to default AND does not mutate the caller-owned params
+  struct (`prm.Search` stays `""` after the call) — for both List and Count;
+  quote-in-value (`O'Brien`) round-trips verbatim against a two-row table so the
+  WHERE result (1 row) differs from the default (2 rows), proving the caller
+  query actually ran; default path builds `SELECT * FROM <target>` from the
+  target arg, never from `prm.Search`.
+- **bad:** malformed `Search` surfaces an error (does not silently succeed).
+
+The filter / LIMIT / ORDER BY / count-filter assertions are the **negative
+control**: verified to FAIL on the pre-fix code for the right reason
+("should have 1 item(s), but has 3", count "expected 2 got 3") and PASS after
+the fix.
+
+`mysql` and `postgres` share the identical fixed block; no live MySQL/Postgres
+instance was available in this environment to run their integration tests, so
+those storages are covered by (a) the shared-code equivalence with sqlite and
+(b) `go build` + `go vet`. See the PR description for exactly what was run vs
+skipped.

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -183,18 +183,15 @@ func (m *MySQL) Count(ctx context.Context, target string, prm *count.Count, opti
 		return 0, customapm.TraceError(ctx, err, m.GetLogger(), m.GetCounterCountedFailed())
 	}
 
-	defaultSearch := "SELECT COUNT(*) FROM " + trgt
-
-	if finalParam.Search == "" {
-		finalParam.Search = defaultSearch
+	// Honor a caller-provided Search; only default when none was supplied.
+	// Copy prm so defaulting never mutates the caller-owned params struct.
+	if prm != nil {
+		prmCopy := *prm
+		finalParam = &prmCopy
 	}
 
-	if prm != nil {
-		if prm.Search != "" {
-			prm.Search = defaultSearch
-		}
-
-		finalParam = prm
+	if finalParam.Search == "" {
+		finalParam.Search = "SELECT COUNT(*) FROM " + trgt
 	}
 
 	//////
@@ -542,18 +539,15 @@ func (m *MySQL) List(ctx context.Context, target string, v any, prm *list.List, 
 		return customapm.TraceError(ctx, err, m.GetLogger(), m.GetCounterListedFailed())
 	}
 
-	defaultSearch := "SELECT * FROM " + trgt
-
-	if finalParam.Search == "" {
-		finalParam.Search = defaultSearch
+	// Honor a caller-provided Search; only default when none was supplied.
+	// Copy prm so defaulting never mutates the caller-owned params struct.
+	if prm != nil {
+		prmCopy := *prm
+		finalParam = &prmCopy
 	}
 
-	if prm != nil {
-		if prm.Search != "" {
-			prm.Search = defaultSearch
-		}
-
-		finalParam = prm
+	if finalParam.Search == "" {
+		finalParam.Search = "SELECT * FROM " + trgt
 	}
 
 	//////

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -174,18 +174,15 @@ func (p *Postgres) Count(ctx context.Context, target string, prm *count.Count, o
 		return 0, customapm.TraceError(ctx, err, p.GetLogger(), p.GetCounterCountedFailed())
 	}
 
-	defaultSearch := "SELECT COUNT(*) FROM " + trgt
-
-	if finalParam.Search == "" {
-		finalParam.Search = defaultSearch
+	// Honor a caller-provided Search; only default when none was supplied.
+	// Copy prm so defaulting never mutates the caller-owned params struct.
+	if prm != nil {
+		prmCopy := *prm
+		finalParam = &prmCopy
 	}
 
-	if prm != nil {
-		if prm.Search != "" {
-			prm.Search = defaultSearch
-		}
-
-		finalParam = prm
+	if finalParam.Search == "" {
+		finalParam.Search = "SELECT COUNT(*) FROM " + trgt
 	}
 
 	//////
@@ -533,18 +530,15 @@ func (p *Postgres) List(ctx context.Context, target string, v any, prm *list.Lis
 		return customapm.TraceError(ctx, err, p.GetLogger(), p.GetCounterListedFailed())
 	}
 
-	defaultSearch := "SELECT * FROM " + trgt
-
-	if finalParam.Search == "" {
-		finalParam.Search = defaultSearch
+	// Honor a caller-provided Search; only default when none was supplied.
+	// Copy prm so defaulting never mutates the caller-owned params struct.
+	if prm != nil {
+		prmCopy := *prm
+		finalParam = &prmCopy
 	}
 
-	if prm != nil {
-		if prm.Search != "" {
-			prm.Search = defaultSearch
-		}
-
-		finalParam = prm
+	if finalParam.Search == "" {
+		finalParam.Search = "SELECT * FROM " + trgt
 	}
 
 	//////

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -174,18 +174,15 @@ func (p *SQLite) Count(ctx context.Context, target string, prm *count.Count, opt
 		return 0, customapm.TraceError(ctx, err, p.GetLogger(), p.GetCounterCountedFailed())
 	}
 
-	defaultSearch := "SELECT COUNT(*) FROM " + trgt
-
-	if finalParam.Search == "" {
-		finalParam.Search = defaultSearch
+	// Honor a caller-provided Search; only default when none was supplied.
+	// Copy prm so defaulting never mutates the caller-owned params struct.
+	if prm != nil {
+		prmCopy := *prm
+		finalParam = &prmCopy
 	}
 
-	if prm != nil {
-		if prm.Search != "" {
-			prm.Search = defaultSearch
-		}
-
-		finalParam = prm
+	if finalParam.Search == "" {
+		finalParam.Search = "SELECT COUNT(*) FROM " + trgt
 	}
 
 	//////
@@ -533,18 +530,15 @@ func (p *SQLite) List(ctx context.Context, target string, v any, prm *list.List,
 		return customapm.TraceError(ctx, err, p.GetLogger(), p.GetCounterListedFailed())
 	}
 
-	defaultSearch := "SELECT * FROM " + trgt
-
-	if finalParam.Search == "" {
-		finalParam.Search = defaultSearch
+	// Honor a caller-provided Search; only default when none was supplied.
+	// Copy prm so defaulting never mutates the caller-owned params struct.
+	if prm != nil {
+		prmCopy := *prm
+		finalParam = &prmCopy
 	}
 
-	if prm != nil {
-		if prm.Search != "" {
-			prm.Search = defaultSearch
-		}
-
-		finalParam = prm
+	if finalParam.Search == "" {
+		finalParam.Search = "SELECT * FROM " + trgt
 	}
 
 	//////

--- a/sqlite/sqlite_list_test.go
+++ b/sqlite/sqlite_list_test.go
@@ -1,0 +1,239 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thalesfsp/dal/v2/internal/shared"
+	"github.com/thalesfsp/params/v2/count"
+	"github.com/thalesfsp/params/v2/list"
+)
+
+//////
+// Shared, process-wide storage.
+//
+// The global metrics registry (internal/metrics.NewInt) panics on a duplicate
+// metric name, so New() — which registers per-storage counters — may only be
+// called ONCE per process. All List/Count behavior tests therefore share a
+// single seeded, file-backed storage built here.
+//////
+
+var (
+	listTestOnce    sync.Once
+	listTestStorage *SQLite
+)
+
+// getTestStorage returns a process-wide, isolated, file-backed SQLite storage
+// with a seeded `test` table plus a `secrets` table (used by the injection
+// test). It runs fully offline (no ENVIRONMENT gating, no docker) so it can
+// exercise the real List/Count code path under `make test`.
+func getTestStorage(ctx context.Context, t *testing.T) *SQLite {
+	t.Helper()
+
+	listTestOnce.Do(func() {
+		// File-backed DB (not shared-cache in-memory) to avoid SQLite shared
+		// cache lock hangs; single connection keeps it deterministic.
+		dbPath := filepath.Join(t.TempDir(), "dal-list-test.db")
+
+		str, err := New(ctx, dbPath)
+		require.NoError(t, err)
+		require.NotNil(t, str)
+		require.NotNil(t, str.Client)
+
+		str.Client.SetMaxOpenConns(1)
+
+		require.NoError(t, str.createTable(ctx, shared.TableName, `
+			id varchar(255) PRIMARY KEY,
+			name varchar(255) NOT NULL,
+			version varchar(255) NOT NULL
+		`))
+
+		// Seed three rows so filters have something to discriminate.
+		seed := []shared.TestDataWithIDS{
+			{ID: "id-1", Name: "alpha", Version: "1.0.0"},
+			{ID: "id-2", Name: "beta", Version: "2.0.0"},
+			{ID: "id-3", Name: "alpha", Version: "3.0.0"},
+		}
+
+		for _, row := range seed {
+			_, err := str.Client.ExecContext(ctx,
+				"INSERT INTO "+shared.TableName+" (id, name, version) VALUES (?, ?, ?)",
+				row.ID, row.Name, row.Version,
+			)
+			require.NoError(t, err)
+		}
+
+		// A second table with TWO rows, one of which has a quote in its value.
+		// Two rows are required so a WHERE clause that matches only one of them
+		// yields a result distinct from the default `SELECT * FROM secrets`
+		// (all rows) — otherwise the verbatim test would pass even on the buggy
+		// code for the wrong reason.
+		_, err = str.Client.ExecContext(ctx,
+			"CREATE TABLE IF NOT EXISTS secrets (id varchar(255) PRIMARY KEY, name varchar(255), version varchar(255))")
+		require.NoError(t, err)
+		_, err = str.Client.ExecContext(ctx,
+			"INSERT INTO secrets (id, name, version) VALUES ('s-1', 'O''Brien', '9.9.9')")
+		require.NoError(t, err)
+		_, err = str.Client.ExecContext(ctx,
+			"INSERT INTO secrets (id, name, version) VALUES ('s-2', 'Nobody', '0.0.1')")
+		require.NoError(t, err)
+
+		listTestStorage = str
+	})
+
+	return listTestStorage
+}
+
+// TestList_HonorsSearch is the negative control for the Search-overwrite bug.
+//
+// On the buggy code, List OVERWRITES a caller-provided prm.Search with the
+// default `SELECT * FROM test`, so a WHERE filter is ignored and ALL rows come
+// back (the "filters" / LIMIT / ORDER BY sub-tests fail for exactly that
+// reason before the fix).
+func TestList_HonorsSearch(t *testing.T) {
+	ctx := context.Background()
+	str := getTestStorage(ctx, t)
+
+	t.Run("happy - nil params returns all rows", func(t *testing.T) {
+		var got []shared.TestDataWithIDS
+		require.NoError(t, str.List(ctx, shared.TableName, &got, nil))
+		assert.Len(t, got, 3, "nil params must return every row (backward compatible)")
+	})
+
+	t.Run("happy - Search filters to the correct subset", func(t *testing.T) {
+		var got []shared.TestDataWithIDS
+		prm := &list.List{Search: "SELECT * FROM " + shared.TableName + " WHERE name = 'beta'"}
+
+		require.NoError(t, str.List(ctx, shared.TableName, &got, prm))
+
+		// BUG (pre-fix): returns all 3 rows because prm.Search is overwritten.
+		require.Len(t, got, 1, "Search WHERE name='beta' must return exactly one row")
+		assert.Equal(t, "id-2", got[0].ID)
+		assert.Equal(t, "beta", got[0].Name)
+	})
+
+	t.Run("edge - Search with LIMIT/OFFSET pagination is honored", func(t *testing.T) {
+		var page1 []shared.TestDataWithIDS
+		require.NoError(t, str.List(ctx, shared.TableName,
+			&page1, &list.List{Search: "SELECT * FROM " + shared.TableName + " ORDER BY id LIMIT 2 OFFSET 0"}))
+		require.Len(t, page1, 2, "LIMIT 2 must cap the first page")
+		assert.Equal(t, "id-1", page1[0].ID)
+		assert.Equal(t, "id-2", page1[1].ID)
+
+		var page2 []shared.TestDataWithIDS
+		require.NoError(t, str.List(ctx, shared.TableName,
+			&page2, &list.List{Search: "SELECT * FROM " + shared.TableName + " ORDER BY id LIMIT 2 OFFSET 2"}))
+		require.Len(t, page2, 1, "OFFSET 2 must return the remainder")
+		assert.Equal(t, "id-3", page2[0].ID)
+	})
+
+	t.Run("edge - Search with ORDER BY controls order", func(t *testing.T) {
+		var got []shared.TestDataWithIDS
+		prm := &list.List{Search: "SELECT * FROM " + shared.TableName + " ORDER BY id DESC"}
+
+		require.NoError(t, str.List(ctx, shared.TableName, &got, prm))
+
+		require.Len(t, got, 3)
+		assert.Equal(t, "id-3", got[0].ID, "ORDER BY id DESC must reverse the order")
+	})
+
+	t.Run("edge - empty Search string falls back to default (all rows)", func(t *testing.T) {
+		var got []shared.TestDataWithIDS
+		// A non-nil params struct with an empty Search must behave like nil.
+		// Pre-fix this produced an empty query string and HUNG the driver; the
+		// fix falls back to the default SELECT.
+		prm := &list.List{Search: ""}
+
+		require.NoError(t, str.List(ctx, shared.TableName, &got, prm))
+		assert.Len(t, got, 3, "empty Search must behave like nil params")
+	})
+
+	t.Run("bad - malformed Search surfaces an error", func(t *testing.T) {
+		var got []shared.TestDataWithIDS
+		prm := &list.List{Search: "SELECT * FROM " + shared.TableName + " WHERE"}
+
+		err := str.List(ctx, shared.TableName, &got, prm)
+		assert.Error(t, err, "a syntactically invalid Search must return an error, not silently succeed")
+	})
+
+	t.Run("edge - Search with a quote in a value is executed verbatim", func(t *testing.T) {
+		// The contract: Search is a caller-controlled query template (documented:
+		// 'It uses param.List.Search to query the data'). DAL must pass it
+		// VERBATIM and never concatenate anything into it. The `secrets` table
+		// has TWO rows; a WHERE that matches exactly one (with a single-quote in
+		// the value, O'Brien) returns 1 row iff the caller's Search actually ran.
+		// On the buggy code prm.Search was overwritten with `SELECT * FROM
+		// secrets` and returned 2 rows, so this discriminates fixed vs buggy.
+		var got []shared.TestDataWithIDS
+		prm := &list.List{Search: "SELECT * FROM secrets WHERE name = 'O''Brien'"}
+
+		require.NoError(t, str.List(ctx, "secrets", &got, prm))
+		require.Len(t, got, 1, "quoted-value WHERE must match exactly one of the two rows")
+		assert.Equal(t, "O'Brien", got[0].Name)
+	})
+
+	t.Run("edge - default path builds SELECT * FROM <target> without touching prm.Search", func(t *testing.T) {
+		// The only interpolation the fix performs is `SELECT * FROM <target>`.
+		// `target` resolves via shared.TargetName from the caller's target arg
+		// (or the storage's configured m.Target) — it never comes from
+		// prm.Search, so a caller Search can never inject into the default path.
+		// With nil params the query is the plain default and returns all rows.
+		var got []shared.TestDataWithIDS
+		require.NoError(t, str.List(ctx, shared.TableName, &got, nil))
+		assert.Len(t, got, 3)
+	})
+
+	t.Run("edge - empty Search does NOT mutate the caller-owned params struct", func(t *testing.T) {
+		// Regression guard: defaulting must not write the default query back into
+		// the caller's struct (it may be reused). Search must remain "" after the
+		// call even though the executed query defaulted to SELECT * FROM target.
+		prm := &list.List{Search: ""}
+		var got []shared.TestDataWithIDS
+
+		require.NoError(t, str.List(ctx, shared.TableName, &got, prm))
+		assert.Len(t, got, 3)
+		assert.Equal(t, "", prm.Search, "caller params.Search must not be mutated by List")
+	})
+}
+
+// TestCount_HonorsSearch guards the identical overwrite bug in Count. It shares
+// the process-wide storage (see getTestStorage) so New() is called only once.
+func TestCount_HonorsSearch(t *testing.T) {
+	ctx := context.Background()
+	str := getTestStorage(ctx, t)
+
+	t.Run("happy - nil params counts all rows", func(t *testing.T) {
+		got, err := str.Count(ctx, shared.TableName, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 3, got)
+	})
+
+	t.Run("happy - Search filters the count", func(t *testing.T) {
+		prm := &count.Count{Search: "SELECT COUNT(*) FROM " + shared.TableName + " WHERE name = 'alpha'"}
+
+		got, err := str.Count(ctx, shared.TableName, prm)
+		require.NoError(t, err)
+
+		// BUG (pre-fix): returns 3 because prm.Search is overwritten.
+		assert.EqualValues(t, 2, got, "Count WHERE name='alpha' must return 2")
+	})
+
+	t.Run("edge - empty Search falls back to default count without mutating params", func(t *testing.T) {
+		prm := &count.Count{Search: ""}
+		got, err := str.Count(ctx, shared.TableName, prm)
+		require.NoError(t, err)
+		assert.EqualValues(t, 3, got, "empty Search must behave like nil params")
+		assert.Equal(t, "", prm.Search, "caller params.Search must not be mutated by Count")
+	})
+
+	t.Run("bad - malformed Search surfaces an error", func(t *testing.T) {
+		_, err := str.Count(ctx, shared.TableName,
+			&count.Count{Search: "SELECT COUNT(*) FROM " + shared.TableName + " WHERE"})
+		require.Error(t, err, "a malformed count Search must error")
+		assert.Contains(t, err.Error(), "count", "error should be tagged as a failed count operation")
+	})
+}


### PR DESCRIPTION
## Summary

The **mysql**, **postgres**, and **sqlite** storages inverted the Search-precedence logic in **both `List` and `Count`**: a non-empty caller `prm.Search` was **overwritten** with the default `SELECT * FROM <target>` (`SELECT COUNT(*) ...` for Count).

**Net effect:** `List`/`Count` could never filter — every call returned the full table/count regardless of the caller's `Search`. A non-nil params struct with an empty `Search` also produced an empty SQL string, which **hangs** the SQLite driver.

Reported by a developer; independently confirmed by codex during a design review.

### Root cause (pre-fix)

```go
defaultSearch := "SELECT * FROM " + trgt
if finalParam.Search == "" { finalParam.Search = defaultSearch } // finalParam is fresh; always ""
if prm != nil {
    if prm.Search != "" { prm.Search = defaultSearch }  // BUG: overwrite caller Search with default
    finalParam = prm
}
```

## Fix (all six sites: mysql/postgres/sqlite × List/Count)

Shallow-copy `prm` and default the query **only when `Search == ""`**; otherwise use the caller's `Search` **verbatim**. The copy ensures DAL's defaulting never mutates the caller-owned params struct.

```go
if prm != nil { prmCopy := *prm; finalParam = &prmCopy }
if finalParam.Search == "" { finalParam.Search = "SELECT * FROM " + trgt }
```

- **Backward compatible:** nil params / no custom `Search` still default to the same `SELECT * FROM <target>`. Public interface unchanged.
- **No untrusted-value concatenation** introduced — `Search` is the documented caller-supplied query template, passed verbatim; the only interpolation is `target` (via `shared.TargetName`, unchanged/pre-existing).

## Blast radius

Affected: **mysql, postgres, sqlite** (identical copy-pasted block). Not affected: elasticsearch, redis, mongodb, s3, file, sftp, memory, dynamodb (own `List`/`Count` impls).

## Consumer backward-compat (proj-ringboost-vendor / UVS)

UVS uses dal elasticsearch (60), redis (40), postgres (5). Every `List`/`Count`-with-`Search` consumer reads `storages[elasticsearch.Name]` (unaffected). The postgres storage is registered but **never has `.List`/`.Count` called** in UVS. **Verdict: the bug does not mask anything in UVS and the fix changes no behavior UVS relies on — fully backward-compatible.**

## Tests

`sqlite/sqlite_list_test.go` (new) exercises the **real** `List`/`Count` code path fully offline (file-backed SQLite, no docker, no `ENVIRONMENT` gate — runs under `make test`):

- **happy:** nil → all rows / full count; `Search` filter → correct subset / filtered count
- **edge:** `LIMIT`/`OFFSET` pagination; `ORDER BY`; empty `Search` → default; quote-in-value (`O'Brien`) executed verbatim against a 2-row table (WHERE→1 row vs default→2, so it discriminates); default path builds `SELECT * FROM <target>` without touching `prm.Search`; **params-not-mutated** guards for List and Count
- **bad:** malformed `Search` surfaces an error

The filter / LIMIT / ORDER BY / verbatim / count-filter assertions are the **negative control** — verified to FAIL on pre-fix code for the right reason (`should have 1 item(s), but has 3`; verbatim `has 2`; count `expected 2 got 3`) and PASS after the fix.

`make test` is green (`-race`). mysql/postgres share the identical fixed block; no live MySQL/Postgres was available here to run their integration suites, so those rely on shared-code equivalence with sqlite plus `go build`/`go vet`.

See `ANALYSIS.md` for the full analysis.

## Validation

codex (read-only, adversarial REFUTE) gate: **SHIP** after addressing its findings (params-mutation copy, strengthened discriminating verbatim test, corrected analysis wording).